### PR TITLE
Find types declared in files with file-scoped namespaces

### DIFF
--- a/Transpiler.cs
+++ b/Transpiler.cs
@@ -257,6 +257,12 @@ partial class Transpiler
                     GetTypeDeclarations(m, model, compilation, types);
                 }
                 break;
+            case SyntaxKind.FileScopedNamespaceDeclaration:
+                var fn = (FileScopedNamespaceDeclarationSyntax)node;
+                foreach (var m in fn.Members) {
+                    GetTypeDeclarations(m, model, compilation, types);
+                }
+                break;
             case SyntaxKind.CompilationUnit:
                 var cu = (CompilationUnitSyntax)node;
                 foreach (var m in cu.Members) {


### PR DESCRIPTION
Allows types in files using file-scoped namespaces to be collected for transpilation. 

e.g.:

MyEnum.cs
```
namespace Test;

public enum MyEnum
{
    A,
    B,
    C
}
```